### PR TITLE
GPIO callback added

### DIFF
--- a/example/blinky.ino
+++ b/example/blinky.ino
@@ -1,0 +1,38 @@
+#include "scheduler.h"
+#include <Arduino.h>
+#include "blinky_led.h"
+#include "FlexiTimer2.h"
+
+blinky_led led1(2, 500, 1); 
+blinky_led led2(3, 750, 1);
+blinky_led led3(4, 1250, 1);
+
+void schedGpioFunc(uint8_t lvl);
+
+void setup() 
+{
+	pinMode(7, OUTPUT);
+	
+	led1.init();
+	led1.enable();
+	led2.init();
+	led2.enable();
+	led3.init();
+	led3.enable();
+	
+	scheduler_o.add_event(&led1);
+	scheduler_o.add_event(&led2);
+	scheduler_o.add_event(&led3);
+	scheduler_o.init(schedGpioFunc);
+	scheduler_o.timer_start();
+}
+
+void loop() 
+{ 
+	scheduler_o.execute_events();
+}
+
+void schedGpioFunc(uint8_t lvl)
+{
+	digitalWrite(7, lvl);
+}

--- a/example/blinky2.ino
+++ b/example/blinky2.ino
@@ -1,0 +1,145 @@
+#include "scheduler.h"
+#include <Arduino.h>
+#include "blinky_led.h"
+#include "button.h"
+#include "FlexiTimer2.h"
+
+blinky_led led1(2, 1000, 1); 
+blinky_led led2(3, 1500, 1);
+blinky_led led3(4, 1750, 1);
+
+button button1(10, 1, 70, 3000);
+button button2(11, 1, 70, 3000);
+button button3(12, 1, 70, 3000);
+
+void button1_sp_callback();
+void button2_sp_callback();
+void button3_sp_callback();
+
+void button1_lp_callback(uint16_t call_count);
+void button2_lp_callback(uint16_t call_count);
+void button3_lp_callback(uint16_t call_count);
+
+void schedGpioFunc(uint8_t lvl);
+
+void setup() 
+{
+	pinMode(7, OUTPUT);
+	
+	led1.init();
+	led1.enable();
+	led2.init();
+	led2.enable();
+	led3.init();
+	led3.enable();
+	
+	button1.init();
+	button1.set_sp_callback(button1_sp_callback);
+	button1.set_lp_callback(button1_lp_callback);
+	button1.enable();
+	
+	button2.init();
+	button2.set_sp_callback(button2_sp_callback);
+	button2.set_lp_callback(button2_lp_callback);
+	button2.enable();
+	
+	button3.init();
+	button3.set_sp_callback(button3_sp_callback);
+	button3.set_lp_callback(button3_lp_callback);
+	button3.enable();
+	
+	scheduler_o.add_event(&led1);
+	scheduler_o.add_event(&led2);
+	scheduler_o.add_event(&led3);
+	scheduler_o.add_event(&button1);
+	scheduler_o.add_event(&button2);
+	scheduler_o.add_event(&button3);
+	scheduler_o.init(schedGpioFunc);
+	scheduler_o.timer_start();
+}
+
+void loop()
+{
+	scheduler_o.execute_events();
+}
+
+
+void button1_sp_callback()
+{
+	uint16_t period;
+	
+	period = led1.get_on_off_time();
+	
+	if(period > 15)
+	{
+		period = period - 15;
+	}
+	led1.set_on_off_time(period);
+}
+	
+void button2_sp_callback()
+{
+	uint16_t period;
+	
+	period = led2.get_on_off_time();
+	
+	if(period > 15)
+	{
+		period = period - 15;
+	}
+	led2.set_on_off_time(period);
+}
+
+void button3_sp_callback()
+{
+	uint16_t period;
+	
+	period = led3.get_on_off_time();
+	
+	if(period > 15)
+	{
+		period = period - 15;
+	}
+	led3.set_on_off_time(period);
+}
+
+void button1_lp_callback(uint16_t call_count)
+{
+	//for this example, only do something the first time calling
+	//this function for a given long press event_callback
+	
+	if(call_count == 1)
+	{
+		//set the led timer to the default value_comp
+		led1.set_on_off_time();
+	}
+}
+
+void button2_lp_callback(uint16_t call_count)
+{
+	//for this example, only do something the first time calling
+	//this function for a given long press event_callback
+	
+	if(call_count == 1)
+	{
+		//set the led timer to the default value_comp
+		led2.set_on_off_time();
+	}
+}
+
+void button3_lp_callback(uint16_t call_count)
+{
+	//for this example, only do something the first time calling
+	//this function for a given long press event_callback
+	
+	if(call_count == 1)
+	{
+		//set the led timer to the default value_comp
+		led3.set_on_off_time();
+	}
+}
+
+void schedGpioFunc(uint8_t lvl)
+{
+	digitalWrite(7, lvl);
+}

--- a/scheduler.h
+++ b/scheduler.h
@@ -1,7 +1,9 @@
 #ifndef SCHEDULER_H    
 #define SCHEDULER_H  
 
-#include "stdint.h"
+#define USE_UTILIZE_FUNC 1
+
+#include <stdint.h>
 
 #define MAX_NUMBER_EVENTS 10
 
@@ -25,7 +27,7 @@ protected:
 	volatile bool enable_flag;
 	volatile uint16_t current_count;
 	uint16_t count_start;
-	void set_counter(uint16_t cnt_start); //automatically resets current_count but doesn't modify enable
+	void set_counter(uint16_t cnt_start);
 private:
 	
 };
@@ -41,12 +43,21 @@ public:
 											//
 	void execute_events();
 	void timer_start();//start
+	void init(void(*func)(uint8_t));
 	void init();
 	friend void update_counts();
 private:
 	polled_event *rootptr;
+	void (*gpioFunc)(uint8_t);
 };
 
+/******************************************************************************
+Need to create an object so that the update_counts() function has something
+to work with.  I would like to pass an object reference to update_counts() function 
+to avoid making it a friend function and to avoid creating the scheduler_o object
+in this file but the callback function passed to FlexiTimer2 is defined as a 
+void (*func)() which has to match the definition of update_counts()
+******************************************************************************/
 extern scheduler scheduler_o;
 
 #endif


### PR DESCRIPTION
Allow the user to provide their own function for setting/clearing a gpio
around actual event execution.  To be used to indicate utilization by
attaching to an LED or probing with a scope.  Compile switch is added so
you don't have to call any gpio function and can improve your code
efficiency.
